### PR TITLE
:hammer: Refactor(custom): clean yarn cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 ENV TZ=Asia/Shanghai
 RUN apk update \
-    && apk add tzdata \
+    && apk add --no-cache tzdata \
     && echo "${TZ}" > /etc/timezone \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && rm /var/cache/apk/*
@@ -9,6 +9,7 @@ RUN yarn config set network-timeout 300000 && \
     #apk add g++ make py3-pip && \
     #yarn global add node-gyp && \
     yarn global add piclist && \
+    yarn cache clean \
     rm -rf /var/cache/apk/* /tmp/*
 
 EXPOSE 36677


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ad4af453-3098-46d1-9e03-40f92eb10079)

images piclisttmp use `yarn cache clean` in Dockerfile,This command makes the mirror smaller.